### PR TITLE
azure-monitor-opentelemetry v1.8.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,11 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/azure-monitor-o
 
 Home: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry
 
-Package license: Apache-2.0 AND MIT
+Package license: MIT
 
 Summary: Microsoft Azure Monitor Opentelemetry Distro Client Library for Python
 
-Development: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry
-
-Documentation: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry/README.md
-
-Microsoft Azure Monitor Opentelemetry Distro Client Library for Python.
+Microsoft Azure Monitor Opentelemetry Distro Client Library for Python
 
 Current build status
 ====================

--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/azure-monitor-o
 
 Home: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry
 
-Package license: MIT
+Package license: Apache-2.0 AND MIT
 
 Summary: Microsoft Azure Monitor Opentelemetry Distro Client Library for Python
 
-Microsoft Azure Monitor Opentelemetry Distro Client Library for Python
+Development: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry
+
+Documentation: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry/README.md
+
+Microsoft Azure Monitor Opentelemetry Distro Client Library for Python.
 
 Current build status
 ====================

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -25,32 +25,41 @@ requirements:
   run:
     - python >=${{ python_min }}
     - azure-core <2.0.0,>=1.28.0
-    - azure-core-tracing-opentelemetry ~=1.0.0b11
-    - azure-monitor-opentelemetry-exporter ~=1.0.0b54
-    - opentelemetry-sdk ~=1.43.0
-    - opentelemetry-instrumentation-django <0.65.0,>=0.64b0
-    - opentelemetry-instrumentation-fastapi <0.65.0,>=0.64b0
-    - opentelemetry-instrumentation-flask <0.65.0,>=0.64b0
-    - opentelemetry-instrumentation-psycopg2 <0.65.0,>=0.64b0
-    - opentelemetry-instrumentation-requests <0.65.0,>=0.64b0
-    - opentelemetry-instrumentation-urllib <0.65.0,>=0.64b0
+    - azure-core-tracing-opentelemetry >=1.0.0b11,<1.1.dev0
+    - azure-monitor-opentelemetry-exporter >=1.0.0b52,<1.1.dev0
+    - opentelemetry-instrumentation-django ==0.64b0
+    - opentelemetry-instrumentation-fastapi ==0.64b0
+    - opentelemetry-instrumentation-flask ==0.64b0
+    - opentelemetry-instrumentation-logging ==0.64b0
+    - opentelemetry-instrumentation-psycopg2 ==0.64b0
+    - opentelemetry-instrumentation-requests ==0.64b0
+    - opentelemetry-instrumentation-urllib ==0.64b0
+    - opentelemetry-instrumentation-urllib3 ==0.64b0
+    - opentelemetry-resource-detector-azure >=0.1.5,<0.2.dev0
+    - opentelemetry-sdk ==1.40.0
 
 tests:
   - python:
       imports:
         - azure
+        - azure.monitor.opentelemetry
+        - azure.monitor.opentelemetry._autoinstrumentation
       pip_check: true
       python_version:
         - ${{ python_min }}.*
         - "*"
 
 about:
-  homepage: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry
-  license: MIT
-  license_file: LICENSE
   summary: Microsoft Azure Monitor Opentelemetry Distro Client Library for Python
+  homepage: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry
   description: |
-    Microsoft Azure Monitor Opentelemetry Distro Client Library for Python
+    Microsoft Azure Monitor Opentelemetry Distro Client Library for Python.
+  repository: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry
+  documentation: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry/README.md
+  license: Apache-2.0 AND MIT
+  license_file:
+    - LICENSE
+    - NOTICE.txt
 
 extra:
   recipe-maintainers:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -36,7 +36,7 @@ requirements:
     - opentelemetry-instrumentation-urllib ==0.64b0
     - opentelemetry-instrumentation-urllib3 ==0.64b0
     - opentelemetry-resource-detector-azure >=0.1.5,<0.2.dev0
-    - opentelemetry-sdk ==1.40.0
+    - opentelemetry-sdk ==1.43.0
 
 tests:
   - python:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,16 +2,15 @@
 schema_version: 1
 
 context:
-  name: azure-monitor-opentelemetry
-  version: "1.8.8"
+  version: "1.8.9"
 
 package:
-  name: ${{ name|lower }}
+  name: azure-monitor-opentelemetry
   version: ${{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/source/${{ name[0] }}/${{ name }}/azure_monitor_opentelemetry-${{ version }}.tar.gz
-  sha256: c6478cac82939230e9af1004b0a147e39b9046a564f3811d65241797f2f9d41d
+  url: https://pypi.org/packages/source/a/azure-monitor-opentelemetry/azure_monitor_opentelemetry-${{ version }}.tar.gz
+  sha256: 9cda4481c52e02cb3e8e11a34d2491fb07000ed32ee655d75de0747e7d24fea7
 
 build:
   number: 0
@@ -26,38 +25,32 @@ requirements:
   run:
     - python >=${{ python_min }}
     - azure-core <2.0.0,>=1.28.0
-    - azure-core-tracing-opentelemetry >=1.0.0b11,<1.1.dev0
-    - azure-monitor-opentelemetry-exporter >=1.0.0b52,<1.1.dev0
-    - opentelemetry-instrumentation-django ==0.61b0
-    - opentelemetry-instrumentation-fastapi ==0.61b0
-    - opentelemetry-instrumentation-flask ==0.61b0
-    - opentelemetry-instrumentation-logging ==0.61b0
-    - opentelemetry-instrumentation-psycopg2 ==0.61b0
-    - opentelemetry-instrumentation-requests ==0.61b0
-    - opentelemetry-instrumentation-urllib ==0.61b0
-    - opentelemetry-instrumentation-urllib3 ==0.61b0
-    - opentelemetry-resource-detector-azure >=0.1.5,<0.2.dev0
-    - opentelemetry-sdk ==1.40.0
+    - azure-core-tracing-opentelemetry ~=1.0.0b11
+    - azure-monitor-opentelemetry-exporter ~=1.0.0b54
+    - opentelemetry-sdk ~=1.43.0
+    - opentelemetry-instrumentation-django <0.65.0,>=0.64b0
+    - opentelemetry-instrumentation-fastapi <0.65.0,>=0.64b0
+    - opentelemetry-instrumentation-flask <0.65.0,>=0.64b0
+    - opentelemetry-instrumentation-psycopg2 <0.65.0,>=0.64b0
+    - opentelemetry-instrumentation-requests <0.65.0,>=0.64b0
+    - opentelemetry-instrumentation-urllib <0.65.0,>=0.64b0
 
 tests:
   - python:
       imports:
-        - azure.monitor.opentelemetry
-        - azure.monitor.opentelemetry._autoinstrumentation
+        - azure
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
-  summary: Microsoft Azure Monitor Opentelemetry Distro Client Library for Python
   homepage: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry
+  license: MIT
+  license_file: LICENSE
+  summary: Microsoft Azure Monitor Opentelemetry Distro Client Library for Python
   description: |
-    Microsoft Azure Monitor Opentelemetry Distro Client Library for Python.
-  repository: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry
-  documentation: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry/README.md
-  license: Apache-2.0 AND MIT
-  license_file:
-    - LICENSE
-    - NOTICE.txt
+    Microsoft Azure Monitor Opentelemetry Distro Client Library for Python
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
- azure-monitor-opentelemetry 1.8.8 -> 1.8.9
- recipe refreshed to current CFE local shape; built + tested locally with rattler-build before this PR